### PR TITLE
Handle missing Supabase env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=your_supabase_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Environment variables
+.env
+.env.*
+!.env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Welcome to your Dyad app
+
+## Environment setup
+
+The app expects Supabase credentials to be available at runtime. Copy
+`.env.example` to `.env` and provide your values:
+
+```
+VITE_SUPABASE_URL=your_supabase_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+```
+
+If these variables are missing, the UI will display a configuration error
+instead of the main interface.

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,9 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase: SupabaseClient | null =
+  supabaseUrl && supabaseAnonKey
+    ? createClient(supabaseUrl, supabaseAnonKey)
+    : null;


### PR DESCRIPTION
## Summary
- Guard Supabase client creation behind environment variable checks.
- Display a configuration error card on the main and source pages when Supabase credentials are absent.
- Document required `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` variables and provide `.env.example`.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/lib/supabaseClient.ts src/pages/Index.tsx src/pages/Source.tsx`
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; A `require()` style import is forbidden)*
- `npm run build` *(fails: Rollup failed to resolve import "@supabase/supabase-js")*

------
https://chatgpt.com/codex/tasks/task_e_68b374a324b8832197c4150f748c16a3