### PR TITLE
Handle upsert errors before updating session id

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -46,16 +46,24 @@ const Index = () => {
 
   const generateSession = async (newImageUrl: string) => {
     const newSessionId = Math.random().toString(36).substring(2, 10);
-    setSessionId(newSessionId);
-    setImageUrl(newImageUrl);
-    setIsRevealed(false);
 
     const { error } = await client
       .from("sessions")
       .upsert({ id: newSessionId, image_url: newImageUrl, is_revealed: false });
+
     if (error) {
       console.error("Failed to create session:", error);
+      toast({
+        variant: "destructive",
+        title: "Session Error",
+        description: "Failed to create session. Please try again.",
+      });
+      return;
     }
+
+    setSessionId(newSessionId);
+    setImageUrl(newImageUrl);
+    setIsRevealed(false);
   };
 
   const handleUrlSubmit = async () => {


### PR DESCRIPTION
## Summary
- Only set the session ID after a successful Supabase upsert
- Show a toast when session creation fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b3897730fc832190a43475b10deb19