### PR TITLE
feat: upload images to supabase storage

### DIFF
--- a/src/lib/uploadImage.ts
+++ b/src/lib/uploadImage.ts
@@ -1,0 +1,14 @@
+import { supabase } from "./supabaseClient";
+
+export async function uploadImage(file: File): Promise<string | null> {
+  if (!supabase) return null;
+  const client = supabase;
+  const filePath = `${crypto.randomUUID()}-${file.name}`;
+  const { error } = await client.storage.from("images").upload(filePath, file);
+  if (error) {
+    console.error("Failed to upload image:", error);
+    return null;
+  }
+  const { data } = client.storage.from("images").getPublicUrl(filePath);
+  return data?.publicUrl ?? null;
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, ChangeEvent } from "react";
 import { supabase } from "@/lib/supabaseClient";
+import { uploadImage } from "@/lib/uploadImage";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -76,19 +77,22 @@ const Index = () => {
   const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file && file.type.startsWith("image/")) {
-      const reader = new FileReader();
-      reader.onload = async (event) => {
-        if (event.target?.result) {
-          await generateSession(event.target.result as string);
-        }
-      };
-      reader.readAsDataURL(file);
-    } else if (file) {
+      const publicUrl = await uploadImage(file);
+      if (publicUrl) {
+        await generateSession(publicUrl);
+      } else {
         toast({
-            variant: "destructive",
-            title: "Invalid File Type",
-            description: "Please select an image file.",
+          variant: "destructive",
+          title: "Upload Failed",
+          description: "Could not upload image. Please try again.",
         });
+      }
+    } else if (file) {
+      toast({
+        variant: "destructive",
+        title: "Invalid File Type",
+        description: "Please select an image file.",
+      });
     }
   };
 


### PR DESCRIPTION
## Summary
- add `uploadImage` helper for Supabase Storage uploads
- store uploaded images in Supabase Storage and use public URL for sessions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden for @supabase/supabase-js)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b38978927483218996666f73a7a3ef