### PR TITLE
Use framer motion for image reveal

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",
+    "framer-motion": "^11.0.0",
     "embla-carousel-react": "^8.3.0",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, ChangeEvent } from "react";
+import { motion } from "framer-motion";
 import { supabase } from "@/lib/supabaseClient";
 import { uploadImage } from "@/lib/uploadImage";
 import { Button } from "@/components/ui/button";
@@ -275,7 +276,7 @@ const Index = () => {
                 </p>
               </div>
 
-              <div className="flex items-center justify-between rounded-lg border p-4">
+              <div className="flex items-center justify-between rounded-lg border border-border bg-background p-4">
                 <div className="space-y-0.5">
                   <Label htmlFor="reveal-switch" className="text-base">Reveal Image</Label>
                   <p className="text-sm text-muted-foreground">
@@ -292,12 +293,15 @@ const Index = () => {
               {imageUrl && (
                 <div>
                   <Label>Image Preview</Label>
-                  <div className="mt-2 rounded-md border aspect-video w-full flex items-center justify-center bg-muted overflow-hidden p-4">
-                    <img src={imageUrl} alt="Preview" className={`max-h-full max-w-full object-contain transition-all duration-300 ease-in-out ${
-                      isRevealed
-                        ? "opacity-100 scale-100"
-                        : "opacity-0 scale-95"
-                    }`} />
+                  <div className="mt-2 rounded-md border border-border aspect-video w-full flex items-center justify-center bg-background overflow-hidden p-4">
+                    <motion.img
+                      src={imageUrl}
+                      alt="Preview"
+                      className="max-h-full max-w-full object-contain"
+                      initial={{ opacity: 0, scale: 0.95 }}
+                      animate={{ opacity: isRevealed ? 1 : 0, scale: isRevealed ? 1 : 0.95 }}
+                      transition={{ duration: 0.3, ease: "easeInOut" }}
+                    />
                   </div>
                 </div>
               )}

--- a/src/pages/Source.tsx
+++ b/src/pages/Source.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { motion } from "framer-motion";
 import { useParams } from "react-router-dom";
 import { supabase } from "@/lib/supabaseClient";
 import {
@@ -70,15 +71,14 @@ const Source = () => {
   }
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-transparent p-4">
-      <img
+    <div className="fixed inset-0 flex items-center justify-center bg-background p-4">
+      <motion.img
         src={data.imageUrl}
         alt="Browser Source"
-        className={`block max-w-full max-h-full object-contain transition-all duration-300 ease-in-out ${
-          data.isRevealed
-            ? "opacity-100 scale-100"
-            : "opacity-0 scale-95"
-        }`}
+        className="block max-w-full max-h-full object-contain"
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: data.isRevealed ? 1 : 0, scale: data.isRevealed ? 1 : 0.95 }}
+        transition={{ duration: 0.3, ease: "easeInOut" }}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- transition images using `<motion.img>` with `initial`/`animate` props
- align overlay and preview containers with `bg-background` and `border-border`
- add `framer-motion` dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b39eca97508321bcda47700ed89626