### PR TITLE
feat: centralize animation variants

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -22,6 +22,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { fadeIn, scaleUp } from "@/utils/animations";
+
+const previewAnimations = {
+  hidden: `${fadeIn.hidden} ${scaleUp.hidden}`,
+  visible: `${fadeIn.visible} ${scaleUp.visible}`,
+};
 
 const Index = () => {
   const sb = supabase;
@@ -293,11 +299,15 @@ const Index = () => {
                 <div>
                   <Label>Image Preview</Label>
                   <div className="mt-2 rounded-md border aspect-video w-full flex items-center justify-center bg-muted overflow-hidden p-4">
-                    <img src={imageUrl} alt="Preview" className={`max-h-full max-w-full object-contain transition-all duration-300 ease-in-out ${
-                      isRevealed
-                        ? "opacity-100 scale-100"
-                        : "opacity-0 scale-95"
-                    }`} />
+                    <img
+                      src={imageUrl}
+                      alt="Preview"
+                      className={`max-h-full max-w-full object-contain transition-all duration-300 ease-in-out ${
+                        isRevealed
+                          ? previewAnimations.visible
+                          : previewAnimations.hidden
+                      }`}
+                    />
                   </div>
                 </div>
               )}

--- a/src/pages/Source.tsx
+++ b/src/pages/Source.tsx
@@ -7,11 +7,17 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { fadeIn, scaleUp } from "@/utils/animations";
 
 interface SourceData {
   imageUrl: string | null;
   isRevealed: boolean;
 }
+
+const imageAnimations = {
+  hidden: `${fadeIn.hidden} ${scaleUp.hidden}`,
+  visible: `${fadeIn.visible} ${scaleUp.visible}`,
+};
 
 const Source = () => {
   const { sessionId } = useParams<{ sessionId: string }>();
@@ -75,9 +81,7 @@ const Source = () => {
         src={data.imageUrl}
         alt="Browser Source"
         className={`block max-w-full max-h-full object-contain transition-all duration-300 ease-in-out ${
-          data.isRevealed
-            ? "opacity-100 scale-100"
-            : "opacity-0 scale-95"
+          data.isRevealed ? imageAnimations.visible : imageAnimations.hidden
         }`}
       />
     </div>

--- a/src/utils/animations.ts
+++ b/src/utils/animations.ts
@@ -1,0 +1,10 @@
+export const fadeIn = {
+  hidden: "opacity-0",
+  visible: "opacity-100",
+};
+
+export const scaleUp = {
+  hidden: "scale-95",
+  visible: "scale-100",
+};
+


### PR DESCRIPTION
## Summary
- add `fadeIn` and `scaleUp` animation helpers
- reuse shared animation variants on Source and Index pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b39ecc90bc832181d33e4c959c7086