### PR TITLE
style: align error pages with app theme

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { motion } from "framer-motion";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { sectionVariants } from "@/utils/animations";
 
 const NotFound = () => {
   const location = useLocation();
@@ -13,18 +15,24 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background text-foreground">
+    <div className="min-h-screen flex items-center justify-center p-4 md:p-8 bg-background text-foreground">
       <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.3 }}
-        className="text-center"
+        variants={sectionVariants}
+        initial="hidden"
+        animate="visible"
+        whileHover="hover"
       >
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-muted-foreground mb-4">Oops! Page not found</p>
-        <a href="/" className="text-primary hover:text-primary/80 underline">
-          Return to Home
-        </a>
+        <Card className="bg-card border border-primary/50 shadow-lg shadow-[0_0_15px_hsl(var(--glow)/0.2)] text-center">
+          <CardHeader>
+            <CardTitle className="text-4xl mb-4">404</CardTitle>
+            <CardDescription className="text-xl mb-4">
+              Oops! Page not found
+            </CardDescription>
+            <a href="/" className="text-primary hover:text-primary/80 underline">
+              Return to Home
+            </a>
+          </CardHeader>
+        </Card>
       </motion.div>
     </div>
   );

--- a/src/pages/Source.tsx
+++ b/src/pages/Source.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
+import { sectionVariants } from "@/utils/animations";
 import { useParams } from "react-router-dom";
 import { supabase } from "@/lib/supabaseClient";
 import {
@@ -53,15 +54,22 @@ const Source = () => {
 
   if (!sb) {
     return (
-      <div className="min-h-screen flex items-center justify-center p-4">
-        <Card>
-          <CardHeader>
-            <CardTitle>Configuration Error</CardTitle>
-            <CardDescription>
-              Supabase environment variables are missing.
-            </CardDescription>
-          </CardHeader>
-        </Card>
+      <div className="min-h-screen flex items-center justify-center p-4 md:p-8 bg-background text-foreground">
+        <motion.div
+          variants={sectionVariants}
+          initial="hidden"
+          animate="visible"
+          whileHover="hover"
+        >
+          <Card className="bg-card border border-primary/50 shadow-lg shadow-[0_0_15px_hsl(var(--glow)/0.2)]">
+            <CardHeader>
+              <CardTitle>Configuration Error</CardTitle>
+              <CardDescription>
+                Supabase environment variables are missing.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </motion.div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- style 404 page with shared card component and motion variants
- apply app theme and animations to Source error state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b3a25c86948321b2e6115905ba7adf