### PR TITLE
Normalize Supabase URL configuration

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,7 +1,47 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+const rawSupabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const supabaseAnonKey = (import.meta.env
+  .VITE_SUPABASE_ANON_KEY as string | undefined)?.trim();
+
+const sanitizeSupabaseUrl = (url: string | undefined): string | undefined => {
+  if (!url) return undefined;
+
+  const trimmed = url.trim();
+  if (!trimmed) return undefined;
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw new Error('Supabase URL must use http or https');
+    }
+    return parsed.origin;
+  } catch {
+    const projectRefPattern = /^[a-z0-9]{20}$/i;
+    const supabaseDomainPattern = /^[a-z0-9.-]+\.supabase\.(co|in)$/i;
+
+    const inferredDomain = projectRefPattern.test(trimmed)
+      ? `${trimmed}.supabase.co`
+      : supabaseDomainPattern.test(trimmed)
+        ? trimmed
+        : undefined;
+
+    if (!inferredDomain) {
+      console.error(
+        'Invalid Supabase URL provided. Expected a full https URL or project reference.'
+      );
+      return undefined;
+    }
+
+    console.warn(
+      `Normalizing Supabase URL. Update VITE_SUPABASE_URL to "https://${inferredDomain}".`
+    );
+
+    return `https://${inferredDomain}`;
+  }
+};
+
+const supabaseUrl = sanitizeSupabaseUrl(rawSupabaseUrl);
 
 export const supabase: SupabaseClient | null =
   supabaseUrl && supabaseAnonKey


### PR DESCRIPTION
## Summary
- sanitize the Supabase URL environment variable before creating the client
- infer the correct https:// URL when a project ref or domain without protocol is provided and warn when normalization occurs
- prevent client creation when the URL cannot be validated so the UI shows the configuration error state instead of triggering DNS failures

## Testing
- npm run lint *(fails: missing @eslint/js package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d949e22c288321afa7be6752c87708